### PR TITLE
Changed the id to the name in the details section

### DIFF
--- a/API/snacks.json
+++ b/API/snacks.json
@@ -133,6 +133,174 @@
       "toppings": "White icing with light blue stripes and purple glitter."
     }
   ],
+  "toppings": [
+    {
+      "id": 1,
+      "name": "Turquoise Icing"
+    },
+    {
+      "id": 2,
+      "name": "Llama Stamp"
+    },
+    {
+      "id": 3,
+      "name": "Pastel Sprinkles"
+    },
+    {
+      "id": 4,
+      "name": "White Icing"
+    },
+    {
+      "id": 5,
+      "name": "Fudge Stripes"
+    },
+    {
+      "id": 6,
+      "name": "Fudge Frosting"
+    },
+    {
+      "id": 7,
+      "name": "Red and Green Sprinkles"
+    },
+    {
+      "id": 8,
+      "name": "White Stripe"
+    },
+    {
+      "id": 9,
+      "name": "Orange Icing"
+    },
+    {
+      "id": 10,
+      "name": "Pumpkin Stamp"
+    },
+    {
+      "id": 11,
+      "name": "Red Stripes"
+    },
+    {
+      "id": 12,
+      "name": "Blue Star Sprinkles"
+    },
+    {
+      "id": 13,
+      "name": "Carved Face"
+    },
+    {
+      "id": 14,
+      "name": "Fudge"
+    },
+    {
+      "id": 15,
+      "name": "Light Blue Stripes"
+    },
+    {
+      "id": 16,
+      "name": "Purple Glitter"
+    }
+  ],
+  "snackToppings": [
+    {
+      "id": 1,
+      "snackId": 1,
+      "toppingId": 1
+    },
+    {
+      "id": 2,
+      "snackId": 1,
+      "toppingId": 2
+    },
+    {
+      "id": 3,
+      "snackId": 2,
+      "toppingId": 4
+    },
+    {
+      "id": 4,
+      "snackId": 2,
+      "toppingId": 3
+    },
+    {
+      "id": 5,
+      "snackId": 3,
+      "toppingId": 4
+    },
+    {
+      "id": 6,
+      "snackId": 4,
+      "toppingId": 6
+    },
+    {
+      "id": 7,
+      "snackId": 4,
+      "toppingId": 7
+    },
+    {
+      "id": 8,
+      "snackId": 4,
+      "toppingId": 8
+    },
+    {
+      "id": 9,
+      "snackId": 5,
+      "toppingId": 9
+    },
+    {
+      "id": 10,
+      "snackId": 5,
+      "toppingId": 10
+    },
+    {
+      "id": 11,
+      "snackId": 6,
+      "toppingId": 4
+    },
+    {
+      "id": 12,
+      "snackId": 6,
+      "toppingId": 11
+    },
+    {
+      "id": 13,
+      "snackId": 6,
+      "toppingId": 12
+    },
+    {
+      "id": 14,
+      "snackId": 7,
+      "toppingId": 5
+    },
+    {
+      "id": 15,
+      "snackId": 8,
+      "toppingId": 13
+    },
+    {
+      "id": 16,
+      "snackId": 9,
+      "toppingId": 14
+    },
+    {
+      "id": 17,
+      "snackId": 10,
+      "toppingId": 14
+    },
+    {
+      "id": 18,
+      "snackId": 11,
+      "toppingId": 4
+    },
+    {
+      "id": 19,
+      "snackId": 11,
+      "toppingId": 15
+    },
+    {
+      "id": 20,
+      "snackId": 11,
+      "toppingId": 16
+    }
+  ],
   "inFlavors": [
     {
       "id": 1,

--- a/scripts/data/apiManager.js
+++ b/scripts/data/apiManager.js
@@ -68,6 +68,6 @@ export const getSnacks = () => {
 }
 
 export const getSingleSnack = (snackId) => {
-	return fetch(`${apiURL}/snacks/${snackId}`)
+	return fetch(`${apiURL}/snacks/${snackId}?_expand=inFlavor&_expand=season&_expand=type&_expand=shape`)
 	.then(response => response.json())
 }

--- a/scripts/snacks/SnackDetails.js
+++ b/scripts/snacks/SnackDetails.js
@@ -1,4 +1,5 @@
 export const SnackDetails = (snackObject) => {
+	console.log(snackObject)
 	return `
 	<div class="col">
 		<div class="card shadow-sm" >
@@ -9,10 +10,10 @@ export const SnackDetails = (snackObject) => {
 				 
 				  <div class="container">
 					<div class="row row-cols-2">
-						<div class="col col-details">Type: ${snackObject.typeId}</div>
-						<div class="col col-details">Shape: ${snackObject.shapeId}</div>
-						<div class="col col-details">Flavor: ${snackObject.inFlavorId}</div>
-						<div class="col col-details">Season: ${snackObject.seasonId}</div>
+						<div class="col col-details">Type: ${snackObject.type.name}</div>
+						<div class="col col-details">Shape: ${snackObject.shape.name}</div>
+						<div class="col col-details">Flavor: ${snackObject.inFlavor.name}</div>
+						<div class="col col-details">Season: ${snackObject.season.name}</div>
 					</div>
 					<div class="row row-cols-1">
 						<div class="col col-details">${snackObject.toppings}</div>


### PR DESCRIPTION
# Description

I have updated the details section so that the names of the properties are displayed instead of id number. 

API fetch updated with _expand
Snack details corrected string interpolation

## Type of change

Please delete options that are not relevant.


- [x] New feature (non-breaking change which adds functionality)

# Testing Instructions
Select details on a snack and the relevant info will populate



# Checklist:

- [x ] My code follows the style guidelines of this project
- [ x] I have performed a self-review of my own code
- [x ] I have commented my code, particularly in hard-to-understand areas
- [ x] My changes generate no new warnings or errors
- [ x] I have added test instructions that prove my fix is effective or that my feature works
