### PR TITLE
edit button only shows up for the admin

### DIFF
--- a/API/snacks.json
+++ b/API/snacks.json
@@ -425,7 +425,7 @@
       "name": "Hexagon"
     },
     {
-      "id":7,
+      "id": 7,
       "name": "Roll"
     }
   ],
@@ -435,6 +435,12 @@
       "email": "ld@ldcc.com",
       "admin": true,
       "id": 1
+    },
+    {
+      "name": "Logan Demmy",
+      "email": "logan@gmail.com",
+      "admin": false,
+      "id": 2
     }
   ]
 }

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,0 +1,28 @@
+# Description
+
+Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
+
+Fixes # (issue)
+
+## Type of change
+
+Please delete options that are not relevant.
+
+- [ ] Bug fix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- [ ] This change requires a documentation update
+
+# Testing Instructions
+
+Please describe the tests required to verify your changes. Provide instructions so PR Tester can check functionality. Please also list any relevant details for your tests
+
+
+
+# Checklist:
+
+- [ ] My code follows the style guidelines of this project
+- [ ] I have performed a self-review of my own code
+- [ ] I have commented my code, particularly in hard-to-understand areas
+- [ ] My changes generate no new warnings or errors
+- [ ] I have added test instructions that prove my fix is effective or that my feature works

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -39,7 +39,8 @@ applicationElement.addEventListener("click", event => {
 		//collect all the details into an object
 		const userObject = {
 			name: document.querySelector("input[name='registerName']").value,
-			email: document.querySelector("input[name='registerEmail']").value
+			email: document.querySelector("input[name='registerEmail']").value,
+			admin: false
 		}
 		registerUser(userObject)
 			.then(dbUserObj => {

--- a/scripts/snacks/SnackDetails.js
+++ b/scripts/snacks/SnackDetails.js
@@ -1,3 +1,5 @@
+import { getLoggedInUser } from "../data/apiManager.js"
+
 export const SnackDetails = (snackObject) => {
 	console.log(snackObject)
 	return `
@@ -21,10 +23,8 @@ export const SnackDetails = (snackObject) => {
 				</div>
 			  	
 				<div class="d-flex justify-content-between align-items-center">
-					<div class="btn-group">
-					<button type="button" class="btn btn-sm btn-outline-secondary" id="editcake__${snackObject.id}" disabled>Edit</button>
-					<button type="button" class="btn btn-sm btn-outline-secondary" id="deletecake__${snackObject.id}" disabled>Delete</button>
-					</div>
+					${getLoggedInUser().admin ? 
+					'<div class="btn-group"><button type="button" class="btn btn-sm btn-outline-secondary" id="editcake__${snackObject.id}" disabled>Edit</button><button type="button" class="btn btn-sm btn-outline-secondary" id="deletecake__${snackObject.id}" disabled>Delete</button></div>' : ""}
                 	<small class="text-muted">Count: ${snackObject.count}</small>
               	</div>
             </div>


### PR DESCRIPTION
# Description

I have added a Boolean to new users which will default to false when added.
A ternary statement had been added to the buttons to see if the logged in user is an admin

## Type of change

Please delete options that are not relevant.
main.js update to login
snackdetail added ternary

- [ x ] New feature (non-breaking change which adds functionality)


# Testing Instructions

Test by creating a new user and select details for a snack, no edit or delete will be listed
When logging in as the admin the buttons appear



# Checklist:

- [x ] My code follows the style guidelines of this project
- [ x] I have performed a self-review of my own code
- [x ] I have commented my code, particularly in hard-to-understand areas
- [x ] My changes generate no new warnings or errors
- [x ] I have added test instructions that prove my fix is effective or that my feature works
